### PR TITLE
fix: use new vite options

### DIFF
--- a/server.mjs
+++ b/server.mjs
@@ -11,7 +11,8 @@ const vite = await createServer({
   root: resolve('.'),
   logLevel: 'info',
   server: {
-    middlewareMode: 'ssr',
+    middlewareMode: true,
+    appType: 'custom',
     watch: {
       // During tests we edit the files too fast and sometimes chokidar
       // misses change events, so enforce polling for consistency


### PR DESCRIPTION
This PR resolves this issue:
``Setting server.middlewareMode to 'ssr' is deprecated, set server.middlewareMode to `true` and appType to 'custom' instead``

This error message is printed into the console when starting the app.